### PR TITLE
Create index with Fp16

### DIFF
--- a/rag/knowledge-bases/features-examples/utils/knowledge_base.py
+++ b/rag/knowledge-bases/features-examples/utils/knowledge_base.py
@@ -727,6 +727,14 @@ class BedrockKnowledgeBase:
                         "method": {
                             "name": "hnsw",
                             "engine": "faiss",
+                            "parameters": {
+                                "encoder": {
+                                    "name": "sq",
+                                    "parameters": {
+                                        "type": "fp16",
+                                        "clip": True
+                                    }
+                            }},
                             "space_type": "l2"
                         },
                     },


### PR DESCRIPTION
Creating the index with FP16 will reduce the memory consumption by 50%